### PR TITLE
Fix setup url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='0.6',
     author='Daniel Richman, Adam Greig',
     author_email='main@danielrichman.co.uk',
-    url='http://www.danielrichman.co.uk/projects/strict-rfc3339.html',
+    url='http://www.danielrichman.co.uk/libraries/strict-rfc3339.html',
     py_modules=['strict_rfc3339'],
     description="Strict, simple, lightweight RFC3339 functions",
     long_description=readme,


### PR DESCRIPTION
The projected url changed from http://www.danielrichman.co.uk/projects/strict-rfc3339 to http://www.danielrichman.co.uk/libraries/strict-rfc3339

The project page includes important links and it looks bad when it points to a page that returns 404