### PR TITLE
Fix optional colon.

### DIFF
--- a/strict_rfc3339.py
+++ b/strict_rfc3339.py
@@ -33,7 +33,7 @@ __all__ = ["validate_rfc3339",
 
 rfc3339_regex = re.compile(
     r"^(\d\d\d\d)\-(\d\d)\-(\d\d)T"
-    r"(\d\d):(\d\d):(\d\d)(\.\d+)?(Z|([+\-])(\d\d):(\d\d))$")
+    r"(\d\d):(\d\d):(\d\d)(\.\d+)?(Z|([+\-])(\d\d):?(\d\d))$")
 
 
 def validate_rfc3339(datestring):

--- a/test_strict_rfc3339.py
+++ b/test_strict_rfc3339.py
@@ -74,6 +74,7 @@ class TestValidateRFC3339(unittest.TestCase):
         assert self.validate("1994-03-14T17:00:00Z")
         assert self.validate("2011-06-23T17:12:00+05:21")
         assert self.validate("1992-03-14T17:04:00-01:42")
+        assert self.validate("2018-08-06T14:30:00+0000")
 
     def test_rejects_trailing(self):
         assert not self.validate("2011-02-28T12:42:21Z123123")


### PR DESCRIPTION
According to ISO 8601 the colon in the time offset is optional.